### PR TITLE
Updates to app.py, codarutils.py, configuration file and environment.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Guide](https://conda.io/docs/user-guide/install/index.html) for more
 details on installing Conda, making the appropriate adjustments for Miniconda3. 
 
 
-Download the qccodar3 code from https://github.com/teresaupdyke/qccodar3
+Download the qccodar code from https://github.com/teresaupdyke/qccodar
 
 Create a conda environment allows the qccodar module and its
 dependencies to run isolated from the installed Python avoiding

--- a/environment.yml
+++ b/environment.yml
@@ -240,7 +240,7 @@ dependencies:
   - zlib=1.2.11=h7795811_1010
   - zstd=1.4.9=h582d3a0_0
   - pip:
-    - hfradarpy==0.1.4.7
+    - hfradarpy==0.1.5
     - numpy==1.20.0
     - watchdog==2.1.6
 prefix: /Users/teresa/miniconda3/envs/qccodar3

--- a/src/qccodar3/config/qccodar.plist
+++ b/src/qccodar3/config/qccodar.plist
@@ -8,6 +8,8 @@
 		<real>30.0</real>
 		<key>number_of_css</key>
 		<real>5.0</real>
+		<key>shorts_minute_filter</key>
+        <string>*00</string>
 	</dict>
 	<key>metric_concatenation</key>
 	<dict>


### PR DESCRIPTION
Added shorts_minute_filter to the configuration file to tell the program which files to send as source inputs to the merge.  For example, if operating with a 25 MHz system and merging seven 10-min interval files, use input files of 30 minutes past the hour “*30” for hourly merged files and “ *[0,3]0” for half hourly merged files.

app.py
Included argument to main function for configuration filename
Added function to load the configuration file

codarutils.py
Updated add_diagnostic_tables to use integer keys.  This makes the code compatible with changes that were made to hfradarpy.
The expected time for a merged files is calculated to work with sampling for different radar systems.  We expect the merge time to fall behind the source time by a certain number of minutes, which is equal to the number of css files divided by 2 (floor division denoted by // in Python) multiplied by the css interval.
Added code to prevent an error when no source files are found for the merge
Added code to delete a merged file if it is based on a single shorts file
Added code to prevent an error when no output file name is returned from run_LLUVMerger